### PR TITLE
releases ci

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run test
+
   release:
     if: "!startsWith(github.event.head_commit.message, '[skip ci]')"
     needs: install-and-test
@@ -32,7 +33,37 @@ jobs:
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          NPM_TOKEN: ${{ secrets.NPMJS_READWRITE_TOKEN }}
       - name: Print Version
         run: echo "Bumped to version ${{ steps.semantic-release.outputs }}"
+
+  publish-to-github-registry:
+    if: "!startsWith(github.event.head_commit.message, '[skip ci]')"
+    needs: release
+    runs-on: ubuntu-latest
+    name: "Releases package to Github Packages registry"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://npm.pkg.github.com/
+          scope: "@blastorg"
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  publish-to-npm:
+    if: "!startsWith(github.event.head_commit.message, '[skip ci]')"
+    needs: release
+    runs-on: ubuntu-latest
+    name: "Releases package to NPM registry"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+          scope: "@blastorg"
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPMJS_READWRITE_TOKEN}}

--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,6 @@ plugins:
 - "@semantic-release/commit-analyzer"
 - "@semantic-release/release-notes-generator"
 - "@semantic-release/changelog"
-- "@semantic-release/npm"
 - - "@semantic-release/git"
   - assets:
     - package.json


### PR DESCRIPTION
- ci(release): removes npm release from semantice release
- ci(release): adds ci steps to release to both registries
