### PR TITLE
feat: add different log formats for file and http on the parse function

### DIFF
--- a/src/log-parser.ts
+++ b/src/log-parser.ts
@@ -91,17 +91,29 @@ export type Events =
   | ValidatedEvent
   | WarmodEvent;
 
-const { length: LENGTH_OF_DATE } = "10/20/2020 - 10:30:50: ";
+const { length: LENGTH_OF_DATE_FILE } = "10/20/2020 - 10:30:50: ";  // File format
+const { length: LENGTH_OF_DATE_HTTP } = "01/28/2024 - 13:11:03.628 - ";  // Http format
 
 export interface IParseOptions {
   parsers?: IBaseParser<Events>[];
+  format?: "file" | "http";
 }
 
-export function parse(rawLog: string, { parsers = defaultParsers }: IParseOptions = {}): Events | undefined {
-  const receivedAt = new Date(rawLog.substring(0, LENGTH_OF_DATE - 2).replace(" - ", " "));
+export function parse(rawLog: string, { parsers = defaultParsers, format="file" }: IParseOptions = {}): Events | undefined {
 
-  const log = rawLog.substring(LENGTH_OF_DATE);
+  let receivedAt: Date;
+  let log: string;
 
+  if (format==="file"){
+    receivedAt = new Date(rawLog.substring(0, LENGTH_OF_DATE_FILE - 2).replace(" - ", " "));
+    log = rawLog.substring(LENGTH_OF_DATE_FILE);
+  } else if (format==="http"){
+    receivedAt = new Date(rawLog.substring(0, LENGTH_OF_DATE_HTTP - 3).replace(" - ", " "));
+    log = rawLog.substring(LENGTH_OF_DATE_HTTP);
+  } else {
+    throw new Error("Invalid format specified.");
+  }
+  
   for (const parser of parsers) {
     const pattern = parser.patterns.find((item) => item.test(log));
 

--- a/tests/received_at.test.ts
+++ b/tests/received_at.test.ts
@@ -1,0 +1,45 @@
+import { ok } from "assert";
+import { parse, IParseOptions } from "../src";
+
+const DATE_FILE = "01/28/2024 - 16:17:18: "
+const DATE_HTTP = "01/28/2024 - 16:17:18.000 - "
+const DATE      = "01/28/2024 16:17:18"
+
+describe("parse function", (): void => {
+  it("should correctly parse the receivedAt date for 'file' format", () => {
+    const log = `${DATE_FILE}"PlayerName<1><[U:1:230970467]><>" connected, address ""`;
+    const options: IParseOptions = {
+      format: 'file'
+    }
+    const result = parse(log, options);
+    const expectedDate = new Date(DATE)
+
+    ok(result !== undefined, `Failed parse log: ${log}`);
+    expect(result).toBeDefined();
+    expect(result.receivedAt).toEqual(expectedDate);
+  });
+
+  it("should correctly parse the receivedAt date for 'http' format", () => {
+    const log = `${DATE_HTTP}"PlayerName<1><[U:1:230970467]><>" connected, address ""`;
+    const options: IParseOptions = {
+      format: 'http'
+    }
+    const result = parse(log, options);
+    const expectedDate = new Date(DATE)
+
+    ok(result !== undefined, `Failed parse log: ${log}`);
+    expect(result).toBeDefined();
+    expect(result.receivedAt).toEqual(expectedDate);
+  });
+
+  it('should use "file" when not specified for backwards compatibility.', () => {
+    const log = `${DATE_FILE}"PlayerName<1><[U:1:230970467]><>" connected, address ""`;
+    const result = parse(log);
+    const expectedDate = new Date(DATE)
+
+    ok(result !== undefined, `Failed parse log: ${log}`);
+    expect(result).toBeDefined();
+    expect(result.receivedAt).toBeInstanceOf(Date);
+    expect(result.receivedAt).toEqual(expectedDate);
+  });
+});


### PR DESCRIPTION
Ref: #14 The date format is different between the logfile and the httplog.

Adds http format parser.

Normal parsing as is before:
`const parsed_log = parse(log_element);`
If you want http parsing you simply do:
`const parsed_log = parse(log_element, { format: "http" });`